### PR TITLE
add lint rule for disallowing lazy build loader usage in prod

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Add `coursera` to the plugins section of your `.eslintrc` configuration file. Yo
 * [coursera/webdriverio-only-single-describe](docs/rules/webdriverio-only-single-describe.md): Only allow a single describe per spec. Good if your tests are run in a parallelized fashion.
 * [coursera/deprecate-require](docs/rules/deprecate-require.md): Warn against requiring certain modules
 * [coursera/deprecate-module-property](docs/rules/deprecate-module-property.md): Warn against using certain properties on certain modules
-
+* [coursera/no-lazy-build-loader](docs/rules/no-lazy-build-loader.md): Disallow use of lazy build loader in production.
 
 
 

--- a/docs/rules/no-lazy-build-loader.md
+++ b/docs/rules/no-lazy-build-loader.md
@@ -1,0 +1,6 @@
+# Disallow unsafe usage of the LazyBuild loader in production. (no-lazy-build-loader)
+
+This rule helps to mark when developers are using the LazyBuild loader. Since
+LazyBuild only works in a development environment, the lint rule forces
+developers to be aware of unsafely leaving it in code before submitting to
+the production environment.

--- a/src/rules/no-lazy-build-loader.js
+++ b/src/rules/no-lazy-build-loader.js
@@ -1,0 +1,43 @@
+/**
+ * @fileoverview Disallow usage of LazyBuild in production.
+ * @author Sumit Gogia
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+	meta: {
+		docs: {
+			description: "Disallow usage of LazyBuild in production.",
+			recommended: false
+		},
+	},
+
+	create: function create(context) {
+		return {
+			'CallExpression': function CallExpression(node) {
+				var callee = node.callee;
+				var args = node.arguments;
+
+				if (callee.name === 'require' && args[0].value.startsWith("lazy-build-loader!")) {
+					context.report({
+						message: "The `lazy-build-loader` cannot be used in production. Please switch back to `lazy`.",
+						node: node
+					});
+				}
+			},
+			'ImportDeclaration': function ImportDeclaration(node) {
+				var source = node.source.value;
+				if (source.startsWith("lazy-build-loader!")) {
+					context.report({
+						message: "The `lazy-build-loader` cannot be used in production. Please switch back to `lazy`.",
+						node: node
+					});
+				}
+			}
+		};
+	}
+};

--- a/src/rules/no-lazy-build-loader.js
+++ b/src/rules/no-lazy-build-loader.js
@@ -9,35 +9,35 @@
 //------------------------------------------------------------------------------
 
 module.exports = {
-	meta: {
-		docs: {
-			description: "Disallow usage of LazyBuild in production.",
-			recommended: false
-		},
-	},
+  meta: {
+    docs: {
+      description: "Disallow usage of LazyBuild in production.",
+      recommended: false
+    },
+  },
 
-	create: function create(context) {
-		return {
-			'CallExpression': function CallExpression(node) {
-				var callee = node.callee;
-				var args = node.arguments;
+  create: function create(context) {
+    return {
+      'CallExpression': function CallExpression(node) {
+        var callee = node.callee;
+        var args = node.arguments;
 
-				if (callee.name === 'require' && args[0].value.startsWith("lazy-build-loader!")) {
-					context.report({
-						message: "The `lazy-build-loader` cannot be used in production. Please switch back to `lazy`.",
-						node: node
-					});
-				}
-			},
-			'ImportDeclaration': function ImportDeclaration(node) {
-				var source = node.source.value;
-				if (source.startsWith("lazy-build-loader!")) {
-					context.report({
-						message: "The `lazy-build-loader` cannot be used in production. Please switch back to `lazy`.",
-						node: node
-					});
-				}
-			}
-		};
-	}
+        if (callee.name === 'require' && args[0].value.startsWith("lazy-build-loader!")) {
+          context.report({
+            message: "The `lazy-build-loader` cannot be used in production. Please switch back to `lazy`.",
+            node: node
+          });
+        }
+      },
+      'ImportDeclaration': function ImportDeclaration(node) {
+        var source = node.source.value;
+        if (source.startsWith("lazy-build-loader!")) {
+          context.report({
+            message: "The `lazy-build-loader` cannot be used in production. Please switch back to `lazy`.",
+            node: node
+          });
+        }
+      }
+    };
+  }
 };

--- a/tests/rules/no-lazy-build-loader.js
+++ b/tests/rules/no-lazy-build-loader.js
@@ -1,0 +1,50 @@
+/**
+ * @fileoverview Disallow usage of LazyBuild in production.
+ * @author Sumit Gogia
+ */
+"use strict";
+
+var rule = require("../../src/rules/no-lazy-build-loader"),
+  RuleTester = require("eslint").RuleTester;
+
+// Helpers
+// ----------------------------------------------------------------------------
+
+function addValidCodeTestOptions(code) {
+  return {
+    code: code,
+    parserOptions: { ecmaVersion: 6, sourceType: "module" }
+  };
+}
+
+function addInvalidCodeTestOptions(code, errorNodeType) {
+  return {
+    code: code,
+    parserOptions: { ecmaVersion: 6, sourceType: "module" },
+    errors: [
+      {
+        message: "The `lazy-build-loader` cannot be used in production. Please switch back to `lazy`.",
+        type: errorNodeType
+      }
+    ]
+  };
+}
+
+// Tests
+// ----------------------------------------------------------------------------
+
+var ruleTester = new RuleTester();
+ruleTester.run("no-lazy-build-loader", rule, {
+  valid: [
+    addValidCodeTestOptions("import 'lazy!bundles/phoenix/components/NotFound'"),
+    addValidCodeTestOptions("import 'lazy!random'"),
+    addValidCodeTestOptions("require('lazy!bundles/phoenix/components/NotFound')"),
+    addValidCodeTestOptions("import module from 'lazy!random'"),
+    addValidCodeTestOptions("const module = require('lazy!bundles/phoenix/components/NotFound')")
+  ],
+
+  invalid: [
+    addInvalidCodeTestOptions("import 'lazy-build-loader!bundles/phoenix/components/NotFound'", "ImportDeclaration"),
+    addInvalidCodeTestOptions("require('lazy-build-loader!bundles/phoenix/components/NotFound')", "CallExpression")
+  ]
+});


### PR DESCRIPTION
cc @jnwng 

Meant to be used to discourage leaving "lazy-build-loader!" in source when pushing to prod - see diff: https://phabricator.dkandu.me/D63750

This is only meant as a temporary aid as the LazyBuild system gets piloted.
The hope is to move to adjusting the dev build configuration (instead of rewriting lazy -> lazy-build-loader) so that artifacts specific to development don't get left all over the source.