### PR TITLE
Add eslint rules discouraging importing across app bundle and into app bundles

### DIFF
--- a/docs/rules/no-non-app-bundle-to-app-bundle-dependencies.md
+++ b/docs/rules/no-non-app-bundle-to-app-bundle-dependencies.md
@@ -1,0 +1,3 @@
+# Discourages imports a non-app bundle to an app bundle(no-non-app-bundle-to-app-bundle-dependencies)
+
+This rule helps to mark when developers are importing from a non-app bundle to an app bundle. App budles should be the leaf nodes of the dependency graph, as they represent separate modular deployable artifacts. Depending on code within an app module leads to a complicated and hard to trace dependency graph that results in base bundle size bloating, as well as other unforseen consequences.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-coursera",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Custom ESLint rules made by Coursera developers for smoother development",
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-coursera",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Custom ESLint rules made by Coursera developers for smoother development",
   "keywords": [
     "eslint",
@@ -40,12 +40,13 @@
     "babel-cli": "^6.11.4",
     "babel-preset-es2015": "^6.13.2",
     "babel-register": "^6.11.6",
-    "eslint": "~2.6.0",
+    "eslint": "^4.11.0",
     "lodash.defaults": "^4.2.0",
     "mocha": "^2.4.5",
     "prettier": "^1.14.0",
     "prettier-eslint": "^8.8.2",
-    "prettier-eslint-cli": "^4.7.1"
+    "prettier-eslint-cli": "^4.7.1",
+    "sinon": "^7.3.2"
   },
   "engines": {
     "node": ">=4"

--- a/src/rules/no-cross-app-dependencies.js
+++ b/src/rules/no-cross-app-dependencies.js
@@ -1,0 +1,57 @@
+/**
+ * @fileoverview Warns when modules within apps (which are bundles in our current folder structure) 
+ * depend on other modules within other apps.
+ * @author Chris Liu
+ */
+"use strict";
+const fs = require('fs');
+const path = require('path');
+const {getAllAppBundleNames, getBundleNameFromFullFilename} = require('../util/bundle_utils');
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    docs: {
+      description: "Discourages imports from one app bundle to another",
+      recommended: true
+    }
+  },
+
+  create: function create(context) {
+    const currentFilename = context.getFilename()
+
+    const baseDirMatchingRegexp = new RegExp('(.*?/static/bundles).*')
+    // Early return: current file we're inspecting is not in a directory nested under bundles.
+    if (!baseDirMatchingRegexp.test(currentFilename)) {
+      return {};
+    }
+    const baseDir = currentFilename.match(baseDirMatchingRegexp)[1];
+
+    const allAppBundleNames = getAllAppBundleNames(baseDir)
+    const currentFileBundleName = getBundleNameFromFullFilename(currentFilename);
+
+    // Early return: current file we're inspecting is not in an app bundle.
+    if (!allAppBundleNames.includes(currentFileBundleName)) {
+      return {};
+    }
+
+    return {
+      ImportDeclaration: function ImportDeclaration(node) {
+        const source = node.source.value;
+        const importedFileBundleName = getBundleNameFromFullFilename(source);
+        const importedFileIsFromAppBundle = importedFileBundleName && allAppBundleNames.includes(importedFileBundleName);
+        if (importedFileIsFromAppBundle && importedFileBundleName !== currentFileBundleName) {
+          context.report({
+            message:
+              `Avoid cross app imports if possible. Importing from ${importedFileBundleName} to ` +
+              `${currentFileBundleName} breaks modularity and couples apps together.`,
+            node: node
+          });
+        }
+        }
+    };
+  }
+};

--- a/src/rules/no-non-app-bundle-to-app-bundle-dependencies.js
+++ b/src/rules/no-non-app-bundle-to-app-bundle-dependencies.js
@@ -1,0 +1,53 @@
+/**
+ * @fileoverview Warns when modules within non-app bundles (e.g anything in js/lib) 
+ * depend on modules in an app bundle.
+ * @author Chris Liu
+ */
+"use strict";
+const fs = require('fs');
+const path = require('path');
+const {getAllAppBundleNames, getBundleNameFromFullFilename} = require('../util/bundle_utils');
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    docs: {
+      description: "Discourages imports from a non-app bundle or lib to an app bundle",
+      recommended: true
+    }
+  },
+
+  create: function create(context) {
+    const currentFilename = context.getFilename()
+
+    const baseDirMatchingRegexp = new RegExp('(.*?/static).*')
+    // Early return: we're not in the `static` dir
+    if (!baseDirMatchingRegexp.test(currentFilename)) {
+      return {};
+    }
+    const baseDir = currentFilename.match(baseDirMatchingRegexp)[1];
+
+    const allAppBundleNames = getAllAppBundleNames(baseDir)
+    const currentFileBundleName = getBundleNameFromFullFilename(currentFilename);
+
+    return {
+      ImportDeclaration: function ImportDeclaration(node) {
+        const source = node.source.value;
+        const importedFileBundleName = getBundleNameFromFullFilename(source);
+        const importedFileIsFromAppBundle = importedFileBundleName && allAppBundleNames.includes(importedFileBundleName);
+        const currentFileIsFromNonAppBundle = !currentFileBundleName || !allAppBundleNames.includes(currentFileBundleName);
+        if (importedFileIsFromAppBundle && currentFileIsFromNonAppBundle) {
+          context.report({
+            message:
+              `Avoid depending on modules in an app bundle from modules outside of app bundles as ` +
+              `to avoid shared bundles having implicit dependencies on apps that people do not expect.`,
+            node: node
+          });
+        }
+        }
+    };
+  }
+};

--- a/src/util/bundle_utils.js
+++ b/src/util/bundle_utils.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const path = require('path');
+
+// Look up the list of app bundles at most once for each node process spun up in the hopes
+// of making this not expensive for linting many files at once.
+let _appBundleNameCache;
+const getAllAppBundleNames = (bundlesBaseDir) => {
+  if (_appBundleNameCache) return _appBundleNameCache;
+
+  const bundleFolders = fs
+    .readdirSync(bundlesBaseDir)
+    .filter(f => fs.statSync(path.join(bundlesBaseDir, f)).isDirectory())
+    .map(folderName => path.join(bundlesBaseDir, folderName));
+
+  const appBundleNames = bundleFolders.filter(folder => {
+    try {
+      const packageJson = JSON.parse(fs.readFileSync(path.join(folder, 'package.json')))
+      return packageJson && packageJson.r2 && packageJson.r2.app
+    } catch (e) {
+      return false;
+    }
+  }).map(bundleName =>  {
+    return bundleName.split('/').reverse()[0];
+  })
+
+  _appBundleNameCache = appBundleNames;
+  return _appBundleNameCache;
+}
+
+const getBundleNameFromFullFilename = (filename) =>  {
+  const bundleNameRegexp = new RegExp('bundles/(.*?)/')
+  if (bundleNameRegexp.test(filename)) {
+    return filename.match(bundleNameRegexp)[1];
+  }
+}
+
+module.exports = {
+  getAllAppBundleNames,
+  getBundleNameFromFullFilename
+};

--- a/tests/rules/no-cross-app-dependencies.js
+++ b/tests/rules/no-cross-app-dependencies.js
@@ -34,8 +34,8 @@ function addInvalidCodeTestOptions(code, filename) {
 // Tests
 // ----------------------------------------------------------------------------
 
-const bundleFileName = "/Users/cliu/base/coursera/web/static/bundles/phoenix/MyPhoenixComponent.jsx";
-const nonBundleFilename = "/Users/cliu/base/coursera/web/static/js/lib/mylib";
+const bundleFileName = "~/base/coursera/web/static/bundles/phoenix/MyPhoenixComponent.jsx";
+const nonBundleFilename = "~/base/coursera/web/static/js/lib/mylib";
 var ruleTester = new RuleTester();
 ruleTester.run("no-cross-app-dependencies", rule, {
   valid: [

--- a/tests/rules/no-cross-app-dependencies.js
+++ b/tests/rules/no-cross-app-dependencies.js
@@ -1,0 +1,51 @@
+"use strict";
+const sinon = require('sinon');
+const bundleUtils = require('../../src/util/bundle_utils');
+sinon.stub(bundleUtils, "getAllAppBundleNames").returns(['phoenix', 'another-bundle']);
+
+const rule = require("../../src/rules/no-cross-app-dependencies");
+const RuleTester = require("eslint").RuleTester;
+
+
+// Helpers
+// ----------------------------------------------------------------------------
+
+function addValidCodeTestOptions(code, filename) {
+  return {
+    code: code,
+    parserOptions: { ecmaVersion: 6, sourceType: "module" },
+    filename
+  };
+}
+
+function addInvalidCodeTestOptions(code, filename) {
+  return {
+    code: code,
+    parserOptions: { ecmaVersion: 6, sourceType: "module" },
+    filename,
+    errors: [
+      {
+        message: /Avoid cross app imports if possible/,
+      }
+    ]
+  };
+}
+
+// Tests
+// ----------------------------------------------------------------------------
+
+const bundleFileName = "/Users/cliu/base/coursera/web/static/bundles/phoenix/MyPhoenixComponent.jsx";
+const nonBundleFilename = "/Users/cliu/base/coursera/web/static/js/lib/mylib";
+var ruleTester = new RuleTester();
+ruleTester.run("no-cross-app-dependencies", rule, {
+  valid: [
+    addValidCodeTestOptions("import 'bundles/phoenix/components/AnotherComponent'", bundleFileName),
+    addValidCodeTestOptions("import 'js/libs/mylib'", bundleFileName),
+    addValidCodeTestOptions("import 'bundles/another-bundle/components/A'", nonBundleFilename),
+  ],
+
+  invalid: [
+    addInvalidCodeTestOptions("import 'bundles/another-bundle/components/A'", bundleFileName),
+  ]
+});
+sinon.restore();

--- a/tests/rules/no-non-app-bundle-to-app-bundle-dependencies.js
+++ b/tests/rules/no-non-app-bundle-to-app-bundle-dependencies.js
@@ -1,0 +1,52 @@
+"use strict";
+const sinon = require('sinon');
+const bundleUtils = require('../../src/util/bundle_utils');
+sinon.stub(bundleUtils, "getAllAppBundleNames").returns(['phoenix']);
+
+const rule = require("../../src/rules/no-non-app-bundle-to-app-bundle-dependencies");
+const RuleTester = require("eslint").RuleTester;
+
+
+// Helpers
+// ----------------------------------------------------------------------------
+
+function addValidCodeTestOptions(code, filename) {
+  return {
+    code: code,
+    parserOptions: { ecmaVersion: 6, sourceType: "module" },
+    filename
+  };
+}
+
+function addInvalidCodeTestOptions(code, filename) {
+  return {
+    code: code,
+    parserOptions: { ecmaVersion: 6, sourceType: "module" },
+    filename,
+    errors: [
+      {
+        message: /Avoid depending on modules in an app bundle from modules outside of app bundles/,
+      }
+    ]
+  };
+}
+
+// Tests
+// ----------------------------------------------------------------------------
+
+const bundleFileName = "/Users/cliu/base/coursera/web/static/bundles/phoenix/MyPhoenixComponent.jsx";
+const nonBundleFilename = "/Users/cliu/base/coursera/web/static/js/lib/mylib";
+var ruleTester = new RuleTester();
+ruleTester.run("no-non-app-bundle-to-app-bundle-dependencies", rule, {
+  valid: [
+    addValidCodeTestOptions("import 'js/libs/lib2'", nonBundleFilename),
+    // The below 2 are valid because the source file is also an app bundle
+    addValidCodeTestOptions("import 'bundles/phoenix/components/A'", bundleFileName),
+    addValidCodeTestOptions("import 'js/libs/mylib'", bundleFileName),
+  ],
+
+  invalid: [
+    addInvalidCodeTestOptions("import 'bundles/phoenix/components/A'", nonBundleFilename),
+  ]
+});
+sinon.restore();

--- a/tests/rules/no-non-app-bundle-to-app-bundle-dependencies.js
+++ b/tests/rules/no-non-app-bundle-to-app-bundle-dependencies.js
@@ -34,8 +34,8 @@ function addInvalidCodeTestOptions(code, filename) {
 // Tests
 // ----------------------------------------------------------------------------
 
-const bundleFileName = "/Users/cliu/base/coursera/web/static/bundles/phoenix/MyPhoenixComponent.jsx";
-const nonBundleFilename = "/Users/cliu/base/coursera/web/static/js/lib/mylib";
+const bundleFileName = "~/base/coursera/web/static/bundles/phoenix/MyPhoenixComponent.jsx";
+const nonBundleFilename = "~/base/coursera/web/static/js/lib/mylib";
 var ruleTester = new RuleTester();
 ruleTester.run("no-non-app-bundle-to-app-bundle-dependencies", rule, {
   valid: [


### PR DESCRIPTION
2 types of dependencies makes our dependency graph nested, hard to understand, and makes code hard to delete:
1. app bundles depending on each other (e.g `onboarding-2018` depends on `onboarding-2017`) resulting in `onboarding-2017` being very hard to delete
2. non-app bundle depends on app bundles (e.g xdp-common depending on xdp, which makes the dependency graph cyclic between the 2 bundles)

See https://phabricator.dkandu.me/D87766 for more details/discussions. I plan on presenting to growth fe biweekly and maybe frontend forum as well if necessary? Comments/thoughts appreciated. 